### PR TITLE
Работа с рендером: Переписал создание скриншотов

### DIFF
--- a/layers/xrRender/r_screenshot.cpp
+++ b/layers/xrRender/r_screenshot.cpp
@@ -2,10 +2,9 @@
 #include "..\xrEngine\xr_effgamma.h"
 #include "..\xrRender\tga.h"
 #include "..\xrEngine\xrImage_Resampler.h"
+#include "..\..\xrEngine\XR_IOConsole.h"
 
 XRCORE_API u32 build_id;
-
-#define GAMESAVE_SIZE 128
 
 IC u32 convert(float c)
 {
@@ -35,6 +34,173 @@ IC void MouseRayFromPoint(Fvector& direction, int x, int y, Fmatrix& m_CamMat)
 }
 
 void CRender::Screenshot(IRender_interface::ScreenshotMode mode, LPCSTR name)
+{
+	if (!Device.b_is_Ready)
+		return;
+
+	BOOL fullscreen = psDeviceFlags.test(rsFullscreen);
+
+	if (fullscreen)
+		R_CHK(HW.pDevice->GetFrontBufferData(NULL, Target->surf_screenshot_normal));
+	else
+		R_CHK(HW.pDevice->GetRenderTargetData(HW.pBaseRT, Target->surf_screenshot_normal));
+
+	D3DLOCKED_RECT rect;
+	R_CHK(Target->surf_screenshot_normal->LockRect(&rect, 0, D3DLOCK_NOSYSLOCK));
+
+	u32* pPixel = (u32*)rect.pBits;
+	u32* pEnd = pPixel + (Device.dwWidth * Device.dwHeight);
+
+	for (; pPixel != pEnd; pPixel++)
+	{
+		u32 p = *pPixel;
+		*pPixel = color_xrgb(color_get_R(p), color_get_G(p), color_get_B(p));
+	}
+
+	R_CHK(Target->surf_screenshot_normal->UnlockRect());
+
+	string64 t_stemp;
+	string_path file_name;
+
+	switch (mode)
+	{
+	case IRender_interface::SM_FOR_GAMESAVE: 
+	{
+		R_CHK(D3DXLoadSurfaceFromSurface(Target->surf_screenshot_gamesave, NULL, NULL, 
+			Target->surf_screenshot_normal, NULL, NULL, D3DX_DEFAULT, NULL));
+
+		ID3DXBuffer* saved = 0;
+		R_CHK(D3DXSaveTextureToFileInMemory(&saved, D3DXIFF_DDS, Target->tex_screenshot_gamesave, NULL));
+
+		IWriter* fs = FS.w_open(name);
+
+		if (fs)
+		{
+			fs->w(saved->GetBufferPointer(), saved->GetBufferSize());
+			FS.w_close(fs);
+		}
+
+		_RELEASE(saved);
+
+		return;
+	} 
+	break;
+	case IRender_interface::SM_NORMAL: 
+	{
+		sprintf_s(file_name, sizeof(string_path), "xray_%d_%s_%s_%s.jpg", build_id, Core.UserName, timestamp(t_stemp),
+				  (g_pGameLevel) ? g_pGameLevel->name().c_str() : "mainmenu");
+
+		ID3DXBuffer* saved = 0;
+		R_CHK(D3DXSaveSurfaceToFileInMemory(&saved, D3DXIFF_JPG, Target->surf_screenshot_normal, NULL, NULL));
+
+		IWriter* fs = FS.w_open("$screenshots$", file_name);
+		R_ASSERT(fs);
+
+		fs->w(saved->GetBufferPointer(), saved->GetBufferSize());
+		FS.w_close(fs);
+
+		_RELEASE(saved);
+
+		return;
+	} 
+	break;
+	case IRender_interface::SM_FOR_LEVELMAP:
+	{
+		if (!g_pGameLevel)
+		{
+			Msg("! Can't capture level map, level does no loaded");
+			return;
+		}
+		
+		sprintf_s(file_name, sizeof(string_path), "level_map_%s_%s.dds", g_pGameLevel->name().c_str(), timestamp(t_stemp));
+		
+		IDirect3DTexture9* texture;
+		R_CHK(HW.pDevice->CreateTexture(2048, 2048, 1, NULL, D3DFMT_DXT1, D3DPOOL_SYSTEMMEM, &texture, NULL));
+
+		IDirect3DSurface9* surface;
+		R_CHK(texture->GetSurfaceLevel(0, &surface));
+		
+		R_CHK(D3DXLoadSurfaceFromSurface(surface, NULL, NULL, Target->surf_screenshot_normal, NULL, NULL, D3DX_DEFAULT, NULL));
+
+		ID3DXBuffer* saved = 0;
+		R_CHK(D3DXSaveSurfaceToFileInMemory(&saved, D3DXIFF_DDS, surface, NULL, NULL));
+
+		IWriter* fs = FS.w_open("$screenshots$", file_name);
+		R_ASSERT(fs);
+
+		fs->w(saved->GetBufferPointer(), saved->GetBufferSize());
+		FS.w_close(fs);
+
+		_RELEASE(surface);
+		_RELEASE(texture);
+
+		_RELEASE(saved);
+
+		return;
+	} 
+	break;
+	case IRender_interface::SM_FOR_CUBEMAP: 
+	{
+		float fov_min, fov_max, fov;
+		fov = Console->GetFloat("fov", fov_min, fov_max);
+
+		if ((int)fov != 90)
+		{
+			if (name[0] == '1')
+				Msg("! Can't capture cubemap, fov != 90 (%d != 90), please set 'fov' to '90'", (int)fov);
+			return;
+		}
+
+		u32 face_size = ps_r_cubemap_size / 4;
+
+		static IDirect3DCubeTexture9* cubemap = NULL;
+		static IDirect3DSurface9* surface[6] = {NULL};
+
+		u32 id = (int)name[0] - (int)'1';
+
+		// begin
+		if (id == 0)
+		{
+			HW.pDevice->CreateCubeTexture(face_size, 1, NULL, D3DFMT_DXT1, D3DPOOL_SYSTEMMEM, &cubemap, NULL);
+		}
+
+		D3DCUBEMAP_FACES face = (D3DCUBEMAP_FACES)id;
+		cubemap->GetCubeMapSurface(face, 0, &surface[id]);
+		R_CHK(D3DXLoadSurfaceFromSurface(surface[id], NULL, NULL, Target->surf_screenshot_normal, NULL, NULL, D3DX_DEFAULT, NULL));
+
+		// end
+		if (id == 5)
+		{
+			sprintf_s(file_name, sizeof(string_path), "cubemap_%s_%s.dds", Core.UserName, timestamp(t_stemp));
+
+			ID3DXBuffer* saved = 0;
+			D3DXSaveTextureToFileInMemory(&saved, D3DXIFF_DDS, cubemap, NULL);
+
+			IWriter* fs = FS.w_open("$screenshots$", file_name);
+			R_ASSERT(fs);
+
+			fs->w(saved->GetBufferPointer(), saved->GetBufferSize());
+			FS.w_close(fs);
+
+			_RELEASE(saved);
+
+			_RELEASE(surface[0]);
+			_RELEASE(surface[1]);
+			_RELEASE(surface[2]);
+			_RELEASE(surface[3]);
+			_RELEASE(surface[4]);
+			_RELEASE(surface[5]);
+
+			_RELEASE(cubemap);
+		}
+
+		return;
+	}
+	break;
+	}
+}
+
+/*void CRender::Screenshot(IRender_interface::ScreenshotMode mode, LPCSTR name)
 {
 	if (!Device.b_is_Ready)
 		return;
@@ -182,4 +348,4 @@ void CRender::Screenshot(IRender_interface::ScreenshotMode mode, LPCSTR name)
 
 _end_:
 	_RELEASE(pFB);
-}
+}*/

--- a/layers/xrRender/xrRender_console.cpp
+++ b/layers/xrRender/xrRender_console.cpp
@@ -22,6 +22,10 @@ xr_token aa_token[] = {{"st_opt_disabled", 0}, {"st_opt_ssaa", 1}, {0, 0}};
 xr_token aa_token[] = {{"st_opt_disabled", 0}, {"st_opt_rgaa", 1}, {"st_opt_dlaa", 2}, {"st_opt_fxaa", 3}, {0, 0}};
 #endif
 
+u32 ps_r_cubemap_size = 2048;
+xr_token cubemap_size_token[] = {{"1024", 1024}, {"2048", 2048}, {"3072", 3072}, 
+					   {"4096", 4096}, {"6144", 6144}, {"8192", 8192}, {0, 0}};
+
 u32 ps_r_aa_iterations = 2;
 xr_token aa_iterations_token[] = {{"st_opt_x1", 1},
 								  {"st_opt_x2", 2},
@@ -606,6 +610,8 @@ void xrRender_initconsole()
 	CMD4(CCC_Float, "r_wallmark_shift_v", &ps_r_WallmarkSHIFT_V, 0.0f, 1.f);
 	CMD4(CCC_Float, "r_wallmark_ttl", &ps_r_WallmarkTTL, 1.0f, 5.f * 60.f);
 	CMD1(CCC_ModelPoolStat, "stat_models");
+
+	CMD3(CCC_Token, "r_cubemap_size", &ps_r_cubemap_size, cubemap_size_token);
 
 	CMD3(CCC_Token, "r_aa_type", &ps_r_aa, aa_token);
 	CMD3(CCC_Token, "r_aa_iterations", &ps_r_aa_iterations, aa_iterations_token);

--- a/layers/xrRender/xrRender_console.h
+++ b/layers/xrRender/xrRender_console.h
@@ -5,6 +5,8 @@
 /*-------------------------------------------------------------------------------*/
 // Render common values
 /*-------------------------------------------------------------------------------*/
+extern ECORE_API u32 ps_r_cubemap_size;
+
 extern ECORE_API u32 ps_r_aa;
 extern ECORE_API u32 ps_r_aa_iterations;
 

--- a/layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
+++ b/layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
@@ -67,6 +67,14 @@ BOOL CRenderTarget::Create()
 		rtWidth = Device.dwWidth;
 		rtHeight = Device.dwHeight;
 	}
+	
+	// SCREENSHOT
+	{
+		D3DFORMAT format = psDeviceFlags.test(rsFullscreen) ? D3DFMT_A8R8G8B8 : HW.Caps.fTarget;
+		R_CHK(HW.pDevice->CreateOffscreenPlainSurface(Device.dwWidth, Device.dwHeight, format, D3DPOOL_SYSTEMMEM, &surf_screenshot_normal, NULL));
+		R_CHK(HW.pDevice->CreateTexture(256, 256, 1, NULL, D3DFMT_DXT1, D3DPOOL_SYSTEMMEM, &tex_screenshot_gamesave, NULL));
+		R_CHK(tex_screenshot_gamesave->GetSurfaceLevel(0, &surf_screenshot_gamesave));
+	}
 
 	// Bufferts
 	RT.create(RTname, rtWidth, rtHeight, HW.Caps.fTarget);

--- a/layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
+++ b/layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
@@ -42,6 +42,10 @@ class CRenderTarget : public IRender_Target
   public:
 	IDirect3DSurface9* pTempZB;
 
+	IDirect3DSurface9* surf_screenshot_normal;	 // HW.fTarget, SM_NORMAL
+	IDirect3DTexture9* tex_screenshot_gamesave;	 // Container of "surf_screenshot_gamesave"
+	IDirect3DSurface9* surf_screenshot_gamesave; // DXT1, SM_FOR_GAMESAVE
+	
   private:
 	BOOL Create();
 	BOOL NeedPostProcess();

--- a/layers/xrRenderPC_R2/r2_rendertarget.cpp
+++ b/layers/xrRenderPC_R2/r2_rendertarget.cpp
@@ -252,6 +252,14 @@ CRenderTarget::CRenderTarget()
 	b_vignette = xr_new<CBlender_vignette>();
 	b_frame_overlay = xr_new<CBlender_frame_overlay>();
 
+	// SCREENSHOT
+	{
+		D3DFORMAT format = psDeviceFlags.test(rsFullscreen) ? D3DFMT_A8R8G8B8 : HW.Caps.fTarget;
+		R_CHK(HW.pDevice->CreateOffscreenPlainSurface(dwWidth, dwHeight, format, D3DPOOL_SYSTEMMEM, &surf_screenshot_normal, NULL));
+		R_CHK(HW.pDevice->CreateTexture(256, 256, 1, NULL, D3DFMT_DXT1, D3DPOOL_SYSTEMMEM, &tex_screenshot_gamesave, NULL));
+		R_CHK(tex_screenshot_gamesave->GetSurfaceLevel(0, &surf_screenshot_gamesave));
+	}
+
 	//	NORMAL
 	{
 		rt_GBuffer_Position.create(r2_RT_GBuffer_Position, dwWidth, dwHeight, D3DFMT_A16B16G16R16F);
@@ -574,6 +582,10 @@ CRenderTarget::~CRenderTarget()
 	t_envmap_1.destroy();
 
 	_RELEASE(rt_smap_ZB);
+
+	_RELEASE(surf_screenshot_normal);
+	_RELEASE(surf_screenshot_gamesave);
+	_RELEASE(tex_screenshot_gamesave);
 
 	// Jitter
 	for (int it = 0; it < TEX_jitter_count; it++)

--- a/layers/xrRenderPC_R2/r2_rendertarget.h
+++ b/layers/xrRenderPC_R2/r2_rendertarget.h
@@ -96,6 +96,10 @@ class CRenderTarget : public IRender_Target
 	IDirect3DTexture9* t_noise_surf[TEX_jitter_count];
 	ref_texture t_noise[TEX_jitter_count];
 
+	IDirect3DSurface9* surf_screenshot_normal; // HW.fTarget, SM_NORMAL
+	IDirect3DTexture9* tex_screenshot_gamesave; // Container of "surf_screenshot_gamesave"
+	IDirect3DSurface9* surf_screenshot_gamesave; // DXT1, SM_FOR_GAMESAVE
+	
   private:
 	// OCCq
 	ref_shader s_occq;

--- a/xrEngine/FDemoRecord.cpp
+++ b/xrEngine/FDemoRecord.cpp
@@ -185,9 +185,10 @@ void CDemoRecord::MakeLevelMapProcess()
 	case 0:
 		s_dev_flags = psDeviceFlags;
 		psDeviceFlags.zero();
-		psDeviceFlags.set(rsClearBB | rsFullscreen | rsDrawStatic, TRUE);
-		if (!psDeviceFlags.equal(s_dev_flags, rsFullscreen))
-			Device.Reset();
+		psDeviceFlags.set(rsClearBB | rsDrawStatic, TRUE);
+		psDeviceFlags.set(rsFullscreen, s_dev_flags.test(rsFullscreen));
+		//if (!psDeviceFlags.equal(s_dev_flags, rsFullscreen))
+		//	Device.Reset();
 		break;
 	case DEVICE_RESET_PRECACHE_FRAME_COUNT + 1: {
 		m_bOverlapped = TRUE;
@@ -239,10 +240,10 @@ void CDemoRecord::MakeLevelMapProcess()
 				  bb.max.x, bb.max.z);
 		Render->Screenshot(IRender_interface::SM_FOR_LEVELMAP, tmp);
 		psHUD_Flags.assign(s_hud_flag);
-		BOOL bDevReset = !psDeviceFlags.equal(s_dev_flags, rsFullscreen);
+		//BOOL bDevReset = !psDeviceFlags.equal(s_dev_flags, rsFullscreen);
 		psDeviceFlags = s_dev_flags;
-		if (bDevReset)
-			Device.Reset();
+		//if (bDevReset)
+		//	Device.Reset();
 		m_bMakeLevelMap = FALSE;
 	}
 	break;


### PR DESCRIPTION
Все виды скриншотов работают в оконном и полноэкранном режиме, на обоих рендерах Подробно:
- SM_NORMAL и SM_FOR_GAMESAVE - создание/удаление сюрфейсов/текстур вынесено в CRenderTarget, скриншоты делаются в разы быстрее
- SM_FOR_LEVELMAP - работает в окне и полноэкранном, не требует Reset
- SM_FOR_CUBEMAP - теперь рендерится в DXT1 Cubemap, размер текстуры выбирается через r_cubemap_size