### PR TITLE
fix: remove CConsole from Engine.Events.Frame on Hide()

### DIFF
--- a/Sources/Runtime/xrEngine/XR_IOConsole.cpp
+++ b/Sources/Runtime/xrEngine/XR_IOConsole.cpp
@@ -750,6 +750,7 @@ void CConsole::Hide()
 
 	Engine.ThreadManager.LegacyFrameMT.Remove(this);
 	Engine.Events.Render.Remove(this);
+	Engine.Events.Frame.Remove(this);
 	m_editor->IR_Release();
 }
 


### PR DESCRIPTION
Fixes #29